### PR TITLE
depend on an actual libc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,7 @@ version = "0.1.0"
 authors = ["Godhuda <engineering+godhuda@tilde.io>"]
 
 [dependencies]
-
-libc = "*"
+libc = "0.2.0"
 
 [dependencies.cslice]
 version = "*"


### PR DESCRIPTION
Depending on * is considered bad practice, and crates.io won't even let you
upload a crate with it.