### PR TITLE
Implement ToRuby for String

### DIFF
--- a/crates/libcruby-sys/src/lib.rs
+++ b/crates/libcruby-sys/src/lib.rs
@@ -92,4 +92,6 @@ extern "C" {
                       arg: void_ptr,
                       state: *mut RubyException)
                       -> VALUE;
+
+    pub fn rb_str_new_cstr(string: c_string) -> VALUE;
 }

--- a/crates/libcruby-sys/src/lib.rs
+++ b/crates/libcruby-sys/src/lib.rs
@@ -60,6 +60,9 @@ extern "C" {
     #[link_name = "HELIX_RARRAY_PTR"]
     pub fn RARRAY_PTR(array: VALUE) -> void_ptr;
 
+    #[link_name = "helix_rb_utf8_str_new"]
+    pub fn rb_utf8_str_new(string: c_string, len: libc::c_long) -> VALUE;
+
     #[link_name = "HELIX_RB_TYPE_P"]
     pub fn RB_TYPE_P(val: VALUE, rb_type: isize) -> bool;
 
@@ -92,7 +95,4 @@ extern "C" {
                       arg: void_ptr,
                       state: *mut RubyException)
                       -> VALUE;
-
-    pub fn rb_str_new_cstr(string: c_string) -> VALUE;
-    pub fn rb_utf8_str_new(string: c_string, len: libc::c_long) -> VALUE;
 }

--- a/crates/libcruby-sys/src/lib.rs
+++ b/crates/libcruby-sys/src/lib.rs
@@ -94,4 +94,5 @@ extern "C" {
                       -> VALUE;
 
     pub fn rb_str_new_cstr(string: c_string) -> VALUE;
+    pub fn rb_utf8_str_new(string: c_string, len: libc::c_long) -> VALUE;
 }

--- a/ruby/ext/helix_runtime/native/helix_runtime.c
+++ b/ruby/ext/helix_runtime/native/helix_runtime.c
@@ -35,6 +35,10 @@ VALUE HELIX_FIX2INT(VALUE v) {
   return FIX2INT(v);
 }
 
+VALUE helix_rb_utf8_str_new(const char* str, long len) {
+  return rb_utf8_str_new(str, len);
+}
+
 int HELIX_TYPE(VALUE v) {
   return TYPE(v);
 }

--- a/ruby/ext/helix_runtime/native/helix_runtime.h
+++ b/ruby/ext/helix_runtime/native/helix_runtime.h
@@ -21,6 +21,8 @@ int HELIX_TYPE(VALUE v);
 VALUE HELIX_INT2FIX(int c_int);
 VALUE HELIX_FIX2INT(VALUE fix);
 
+VALUE helix_rb_utf8_str_new(const char* str, long len);
+
 extern int HELIX_T_NONE;
 extern int HELIX_T_NIL;
 extern int HELIX_T_OBJECT;

--- a/src/coercions/string.rs
+++ b/src/coercions/string.rs
@@ -1,3 +1,4 @@
+use libc;
 use std;
 use sys;
 use sys::{VALUE};
@@ -28,7 +29,8 @@ impl ToRust<String> for CheckedValue<String> {
 
 impl ToRuby for String {
     fn to_ruby(self) -> VALUE {
+        let len = self.len();
         let cstr = CString::new(self).unwrap();
-        unsafe { sys::rb_str_new_cstr(cstr.as_ptr()) }
+        unsafe { sys::rb_utf8_str_new(cstr.as_ptr(), len as libc::c_long) }
     }
 }

--- a/src/coercions/string.rs
+++ b/src/coercions/string.rs
@@ -29,8 +29,8 @@ impl ToRust<String> for CheckedValue<String> {
 
 impl ToRuby for String {
     fn to_ruby(self) -> VALUE {
+        let ptr = self.as_ptr();
         let len = self.len();
-        let cstr = CString::new(self).unwrap();
-        unsafe { sys::rb_utf8_str_new(cstr.as_ptr(), len as libc::c_long) }
+        unsafe { sys::rb_utf8_str_new(ptr as *const libc::c_char, len as libc::c_long) }
     }
 }

--- a/src/coercions/string.rs
+++ b/src/coercions/string.rs
@@ -3,7 +3,7 @@ use sys;
 use sys::{VALUE};
 use std::ffi::CString;
 
-use super::{UncheckedValue, CheckResult, CheckedValue, ToRust};
+use super::{UncheckedValue, CheckResult, CheckedValue, ToRust, ToRuby};
 
 // VALUE -> to_coercible_rust<String> -> CheckResult<String> -> unwrap() -> Coercible<String> -> to_rust() -> String
 
@@ -23,5 +23,12 @@ impl ToRust<String> for CheckedValue<String> {
         let ptr = unsafe { sys::RSTRING_PTR(self.inner) };
         let slice = unsafe { std::slice::from_raw_parts(ptr as *const u8, size as usize) };
         unsafe { std::str::from_utf8_unchecked(slice) }.to_string()
+    }
+}
+
+impl ToRuby for String {
+    fn to_ruby(self) -> VALUE {
+        let cstr = CString::new(self).unwrap();
+        unsafe { sys::rb_str_new_cstr(cstr.as_ptr()) }
     }
 }


### PR DESCRIPTION
Hi @wycats, @chancancode!

I've been really excited about this project since last year when it was still called TurboRuby. I was really happy to see it come back as Helix at RailsConf this year!

I was playing around with the library and noticed that the only types that have `ToRuby` implementations so far are `()` and `bool`. Implementing the trait for `String` seemed straightforward, so I took a try at it.

I am definitely not an expert at Rust or MRI, so I'm not sure if this is the correct way to handle this. Please let me know!