### PR TITLE
Readme for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Running the examples
+
+Tested with:
+
+
+cargo 0.11.0-nightly (3ff108a 2016-05-24)
+
+rustc 1.11.0-nightly (a967611d8 2016-05-30)
+
+ruby 2.3.1p112 (2016-04-26 revision 54768)
+
+Bundler version 1.12.5
+
+### Main
+1. In the main project `cargo build --release`
+
+### Ruby gem
+1. Go to helix/ruby
+2. `bundle install`
+  * [requires neversaydie](https://github.com/tenderlove/neversaydie)
+3. `bundle exec rake`
+
+### Example
+1. go to helix/examples/project-name
+2. `bundle install`
+3. `bundle exec gem install ../../ruby/pkg/helix_runtime-0.5.0.gem`
+4. `cargo build --release`
+5. `bundle exec rake irb IMPLEMENTATION=RUST`
+


### PR DESCRIPTION
Dearest Reviewer,

I want to check out the examples and get them running. I think this is
everything I had to do to get the membership benchmarks running. The odd
thing is that the benchmarks run fine but the rake irb command gives
this warning.

```
gcc -Wl,-force_load,target/release/libmembership.a --shared
-Wl,-undefined,dynamic_lookup -o lib/membership/native.bundle
Ignoring helix_runtime-0.5.0 because its extensions are not built.  Try:
gem pristine helix_runtime --version 0.5.0
```

I added the bundle install command to try and help it but it does not
seem to have helped. I could remove that step I think. Let me know.

Anyway, Thanks!
Becker